### PR TITLE
Revert "Ensure objects are sorted by ID when calling getObjectsOrderedById()"

### DIFF
--- a/src/Test/Stubs/SourceStub.php
+++ b/src/Test/Stubs/SourceStub.php
@@ -21,10 +21,6 @@ class SourceStub implements SourceAdapter
 
     public function getObjectsOrderedById()
     {
-        usort($entities, function($a, $b) {
-            return $a->getId() <=> $b->getId();
-        });
-
         return $this->objects;
     }
 }


### PR DESCRIPTION
This reverts commit 31b3611813b22f9e981836682583807503c5c1ce.

If the change was not necessary to fix tests, does it have any other purpose?