### PR TITLE
Reduce log level for events that make most of the log volume with least of newsworthiness

### DIFF
--- a/src/Synchronizer.php
+++ b/src/Synchronizer.php
@@ -222,7 +222,7 @@ final class Synchronizer
         }
 
         if (!$mapResult->getObjectHasChanged()) {
-            $this->logger->info('Kept object with id {id}.', ['id' => $this->mapper->idOf($sourceObject)]);
+            $this->logger->debug('Kept object with id {id}.', ['id' => $this->mapper->idOf($sourceObject)]);
 
             return;
         }


### PR DESCRIPTION
These messages make up most of the log volume, yet only indicate that nothing has happened. 

Let's reduce them to the `debug` log level.