### PR TITLE
Allow PHP 8.4 to be used

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,11 +16,9 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - { php-version: 7.2, dependency-version: prefer-lowest }
-                    - { php-version: 7.4, dependency-version: prefer-stable }
+                    - { php-version: 8.1, dependency-version: prefer-lowest }
                     - { php-version: 8.1, dependency-version: prefer-stable }
-                    - { php-version: 8.2, dependency-version: prefer-stable }
-                    - { php-version: 8.3, dependency-version: prefer-stable }
+                    - { php-version: 8.4, dependency-version: prefer-stable }
         name: PHPUnit (PHP ${{matrix.php-version}}, ${{ matrix.dependency-version }})
         steps:
             -   uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,12 @@
     ],
 
     "require": {
-        "php": "^7.2|8.0.*|8.1.*|8.2.*|8.3.*",
+        "php": ">= 8.1",
         "psr/log": "^1|^2|^3"
     },
 
     "require-dev": {
-        "phpunit/phpunit": "^8.5|^9.5|^10.5",
-        "symfony/error-handler": "^5.4|^6.4|^7.1",
-        "symfony/phpunit-bridge": ">= 6.0"
+        "phpunit/phpunit": "^10.5.58"
     },
 
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" cacheDirectory=".phpunit.cache">
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+    cacheDirectory=".phpunit.cache"
+    failOnPhpunitDeprecation="true"
+    failOnDeprecation="true"
+>
     <testsuites>
         <testsuite name="Project Test Suite">
             <directory>tests</directory>


### PR DESCRIPTION
Also, include it in the test matrix. At the same time, time to let go of old versions.
